### PR TITLE
p0ng hotfix 1.0.2

### DIFF
--- a/p0ng/project.godot
+++ b/p0ng/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="p0ng"
-config/version="1.0.0"
+config/version="1.0.2"
 run/main_scene="res://scenes/main.tscn"
 config/use_custom_user_dir=true
 config/custom_user_dir_name="ambientlamp/p0ng"

--- a/p0ng/scripts/scenes/settings_menu/settings_menu.gd
+++ b/p0ng/scripts/scenes/settings_menu/settings_menu.gd
@@ -7,7 +7,7 @@ extends GameScene2D
 # ============================================================================ #
 #region Godot builtins
 func _ready() -> void:
-    _load_config()
+    _ui_load_config()
     _ui.connect("acted", _on_main_menu_ui_acted)
     _ui.connect("acted_with_data", _on_main_menu_ui_acted_with_data)
 #endregion
@@ -25,6 +25,7 @@ func _on_main_menu_ui_acted(action: StringName) -> void:
         "reset_defaults":
             GameConfig.reset_config()
             GameConfig.save_config()
+            _ui_load_config()
 
 
 # Listens to $UIContainer/MainMenuUI.acted_with_data(action: StringName, data: Variant).
@@ -70,10 +71,14 @@ func _on_main_menu_ui_acted_with_data(action: StringName, data: Variant) -> void
 
 # ============================================================================ #
 #region Utils
-func _load_config() -> void:
+func _ui_load_config() -> void:
     var ui_graphics = _ui.get_node("Graphics")
     ui_graphics.get_node("Resolution/OptionButton").text =\
             GameConfig.config.graphics.resolution
+    for resolution_option_item: OptionItem in _ui.resolution_option_items:
+        if resolution_option_item.text == GameConfig.config.graphics.resolution:
+            resolution_option_item.button_pressed = true
+            break
     ui_graphics.get_node("Fullscreen/ToggleButton").button_pressed =\
             GameConfig.config.graphics.fullscreen
     ui_graphics.get_node("PostProcessing/ToggleButton").button_pressed =\

--- a/p0ng/scripts/scenes/settings_menu/settings_menu_ui.gd
+++ b/p0ng/scripts/scenes/settings_menu/settings_menu_ui.gd
@@ -197,10 +197,9 @@ func _on_resolution_option_item_selected(text: String) -> void:
 
 
 #region Listens to _sounds.get_node("*").
-func _on_sounds_master_volume_slider_updated(value_changed: bool) -> void:
-    if value_changed:
-        var slider: Range = _sounds.get_node("MasterVolume/HSlider")
-        acted_with_data.emit("sounds_master_volume_slider_updated", slider.value)
+func _on_sounds_master_volume_slider_updated(_value_changed: bool) -> void:
+    var slider: Range = _sounds.get_node("MasterVolume/HSlider")
+    acted_with_data.emit("sounds_master_volume_slider_updated", slider.value)
 
 
 func _on_sounds_master_volume_mute_toggled(toggled_on: bool) -> void:
@@ -208,10 +207,9 @@ func _on_sounds_master_volume_mute_toggled(toggled_on: bool) -> void:
     acted_with_data.emit("sounds_master_volume_mute_toggled", toggled_on)
 
 
-func _on_sounds_ui_volume_slider_updated(value_changed: bool) -> void:
-    if value_changed:
-        var slider: Range = _sounds.get_node("UIVolume/HSlider")
-        acted_with_data.emit("sounds_ui_volume_slider_updated", slider.value)
+func _on_sounds_ui_volume_slider_updated(_value_changed: bool) -> void:
+    var slider: Range = _sounds.get_node("UIVolume/HSlider")
+    acted_with_data.emit("sounds_ui_volume_slider_updated", slider.value)
 
 
 func _on_sounds_ui_volume_mute_toggled(toggled_on: bool) -> void:
@@ -219,10 +217,9 @@ func _on_sounds_ui_volume_mute_toggled(toggled_on: bool) -> void:
     acted_with_data.emit("sounds_ui_volume_mute_toggled", toggled_on)
 
 
-func _on_sounds_gameplay_volume_slider_updated(value_changed: bool) -> void:
-    if value_changed:
-        var slider: Range = _sounds.get_node("GameplayVolume/HSlider")
-        acted_with_data.emit("sounds_gameplay_volume_slider_updated", slider.value)
+func _on_sounds_gameplay_volume_slider_updated(_value_changed: bool) -> void:
+    var slider: Range = _sounds.get_node("GameplayVolume/HSlider")
+    acted_with_data.emit("sounds_gameplay_volume_slider_updated", slider.value)
 
 
 func _on_sounds_gameplay_volume_mute_toggled(toggled_on: bool) -> void:
@@ -280,9 +277,8 @@ func _on_option_button_item_selected(_index: int) -> void:
 
 # Listens to drag_ended(value_changed: bool) of ui_scene_changer_buttons that is
 # of type Slider.
-func _on_slider_drag_ended(value_changed: bool) -> void:
-    if value_changed:
-        _on_ui_accepted_button_pressed()
+func _on_slider_drag_ended(_value_changed: bool) -> void:
+    _on_ui_accepted_button_pressed()
 
 
 # Listens to tween transition Tween.finished() from reset_defaults to re-enable

--- a/p0ng/scripts/scenes/settings_menu/settings_menu_ui.gd
+++ b/p0ng/scripts/scenes/settings_menu/settings_menu_ui.gd
@@ -3,7 +3,9 @@ extends UI
 
 @export var settings_modified_message: String
 
-var _resolution_option_items: Array = Array()
+## Contains the [OptionItem] resolution buttons in the
+## [code]$ResolutionPopup[/code].
+var resolution_option_items: Array = Array()
 
 @onready var _main: Container = $Main/Menu/VBoxContainer
 @onready var _graphics: Container = $Graphics
@@ -148,7 +150,7 @@ func _on_graphics_resolution_option_button_pressed() -> void:
             )
     )
 
-    for resolution_option_item in _resolution_option_items:
+    for resolution_option_item in resolution_option_items:
         if resolution_option_item.text == GameConfig.config.graphics.resolution:
             resolution_option_item.grab_focus()
             break
@@ -181,7 +183,7 @@ func _on_graphics_menu_back_button_pressed() -> void:
 #endregion
 
 
-# Listens to _resolution_option_items.[*].selected().
+# Listens to resolution_option_items.[*].selected().
 func _on_resolution_option_item_selected(text: String) -> void:
     if text != GameConfig.config.graphics.resolution:
         var resolution_option_button: Button = _graphics.get_node("Resolution/OptionButton")
@@ -318,28 +320,26 @@ func _configure_resolution_popup() -> void:
         resolution_option_item.add_to_group("ui_accepted_buttons")
         resolution_popup_container.add_child(resolution_option_item)
 
-        _resolution_option_items.push_back(resolution_option_item)
+        resolution_option_items.push_back(resolution_option_item)
         resolution_option_item.focus_neighbor_left = "."
         resolution_option_item.focus_neighbor_right = "."
         if i > 0:
-            var prev_option_item_path: String = "../%s" % _resolution_option_items[i - 1].name
+            var prev_option_item_path: String = "../%s" % resolution_option_items[i - 1].name
             var this_option_item_path: String = "../%s" % resolution_option_item.name
 
-            _resolution_option_items[i - 1].focus_neighbor_bottom = NodePath(this_option_item_path)
-            _resolution_option_items[i - 1].focus_next = NodePath(this_option_item_path)
+            resolution_option_items[i - 1].focus_neighbor_bottom = NodePath(this_option_item_path)
+            resolution_option_items[i - 1].focus_next = NodePath(this_option_item_path)
             resolution_option_item.focus_neighbor_top = NodePath(prev_option_item_path)
             resolution_option_item.focus_previous = NodePath(prev_option_item_path)
 
             if i == resolution_keys.size() - 1:
-                var first_option_item = _resolution_option_items[0]
+                var first_option_item = resolution_option_items[0]
                 var first_option_item_path: String = "../%s" % first_option_item
                 resolution_option_item.focus_neighbor_bottom = NodePath(first_option_item_path)
                 resolution_option_item.focus_next = NodePath(first_option_item_path)
                 first_option_item.focus_neighbor_top = NodePath(this_option_item_path)
                 first_option_item.focus_previous = NodePath(this_option_item_path)
 
-        if resolution_key == GameConfig.config.graphics.resolution:
-            resolution_option_item.button_pressed = true
         if (
                 resolution.x > current_resolution.x
                 or resolution.y > current_resolution.y


### PR DESCRIPTION
Fixed two issues:
- Resolved #15 
- Workaround for issue: When clicking on HSlider, `drag_ended(value_changed: bool)` is emitted, but `value_changed` is not `true` even when the user did change the value of the slider. Solution: Stop checking `value_changed`, instead always take the current value after `drag_ended`.
